### PR TITLE
Adjust versioning of d2l-fetch and d2l-fetch-auth so it matches those…

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "@chaitin/querystring": "^1.1.0",
     "@polymer/polymer": "^3.2.0",
     "@webcomponents/webcomponentsjs": "^2",
-    "d2l-fetch": "git://github.com/Brightspace/d2l-fetch.git#semver:^2",
-    "d2l-fetch-auth": "git://github.com/Brightspace/d2l-fetch-auth.git#semver:^1",
+    "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
+    "d2l-fetch-auth": "^1.5.2",
     "lit-element": "^2",
     "pwa-helpers": "^0.9.1"
   },


### PR DESCRIPTION
… used in BSI

Running into these errors in the BSI build:
```
Polymer sub-dependency detected "d2l-fetch" in "d2l-content-store". All Polymer dependencies must be at root level of "package-lock.json" to avoid duplicate registrations. Check that the version ranges in "package.json" do not contain anything beyond the major version.
Polymer sub-dependency detected "d2l-fetch-auth" in "d2l-content-store". All Polymer dependencies must be at root level of "package-lock.json" to avoid duplicate registrations. Check that the version ranges in "package.json" do not contain anything beyond the major version.
```

What's used in BSI:
https://github.com/Brightspace/brightspace-integration/blob/master/package.json#L85
https://github.com/Brightspace/brightspace-integration/blob/master/package.json#L86

This change should fix it.
