### PR TITLE
Adding relative date formatter

### DIFF
--- a/src/components/relative-date.js
+++ b/src/components/relative-date.js
@@ -1,10 +1,12 @@
 import { LitElement, html } from 'lit-element';
-import { formatDate, formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { formatRelativeDate } from '../util/date-time.js';
 
 class RelativeDate extends LitElement {
 	static get properties() {
 		return {
-			value: { type: String }
+			value: { type: String },
+			relative: { type: String, attribute: false }
 		};
 	}
 
@@ -12,8 +14,12 @@ class RelativeDate extends LitElement {
 		super.firstUpdated();
 		const date = new Date(Date.parse(this.value));
 		this.absolute = formatDateTime(date, { format: 'full' });
-		this.relative = formatDate(date, { format: 'short' });
-		this.requestUpdate();
+
+		formatRelativeDate(date, {
+			onUpdate: text => {
+				this.relative = text;
+			}
+		});
 	}
 
 	render() {

--- a/src/util/date-time.js
+++ b/src/util/date-time.js
@@ -1,0 +1,104 @@
+import { formatDateTime, formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
+import { getLanguage } from '@brightspace-ui/intl/lib/common.js';
+
+const second = 1000;
+const minute = 60 * second;
+const hour = 60 * minute;
+const day = 24 * hour;
+const thirtySeconds = 30 * second;
+const halfHour = 30 * minute;
+const hourAndHalf = 90 * minute;
+const fortyFiveMinutes = 45 * minute;
+const threeAndAHalfDays = 84 * hour;
+const sixHours = 6 * hour;
+
+const defaultRtf = Intl && Intl.RelativeTimeFormat &&
+	new Intl.RelativeTimeFormat(getLanguage(), {
+		localeMatcher: 'best fit',
+		numeric: 'auto',
+		style: 'long'
+	});
+
+const midnightTime = dateTime =>
+	new Date(
+		dateTime.getFullYear(),
+		dateTime.getMonth(),
+		dateTime.getDate()
+	).getTime();
+
+const noonTime = dateTime =>
+	new Date(
+		dateTime.getFullYear(),
+		dateTime.getMonth(),
+		dateTime.getDate(),
+		12
+	).getTime();
+
+// Adapted from:
+// https://search.d2l.dev/xref/lms/lp/framework/web/D2L.LP.Web/UI/JavaScript/Globalization/Formatting/DateTime/DateTimeFormatter.js?r=438b5dc3#125
+//
+// but modified to work with:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat
+//
+const formatRelative = formatFunction => (inputDate, {
+	absoluteFormat = 'short',
+	origin = new Date(),
+	onUpdate = null,
+	rtf = defaultRtf
+} = {}) => {
+	const midnight = midnightTime(origin);
+	const noon = noonTime(origin);
+	const now = origin.getTime();
+
+	const sameDay = midnightTime(inputDate) === midnight;
+	const timespan = inputDate.getTime() - origin.getTime();
+	const timespanFromNoon = inputDate.getTime() - noon;
+	const timespanAbs = Math.abs(timespan);
+	const isPast = timespan < 0;
+
+	let text;
+	let timeout;
+	if (rtf && timespanAbs < thirtySeconds) {
+		text = rtf.format(Math.round(timespan / second), 'second');
+		timeout = isPast ?
+			thirtySeconds - timespanAbs :
+			thirtySeconds + timespanAbs;
+	} else if (rtf && timespanAbs < fortyFiveMinutes) {
+		text = rtf.format(Math.round(timespan / minute), 'minute');
+		timeout = minute;
+	} else if (rtf && (timespanAbs < sixHours || sameDay)) {
+		const minutes = (timespanAbs % hour);
+		text = rtf.format(Math.round(timespan / hour), 'hour');
+		timeout = (isPast ? hourAndHalf - minutes : halfHour + minutes) % hour;
+	} else if (rtf && Math.abs(timespanFromNoon) < threeAndAHalfDays) {
+		text = rtf.format(Math.round(timespanFromNoon / day), 'day');
+		timeout = noon - now + (now < noon ? 0 : day);
+	} else {
+		text = formatFunction(inputDate, { format: absoluteFormat });
+		timeout = -1;
+	}
+
+	if (timeout > 0) {
+		timeout = Math.max(timeout, 1000);
+	}
+
+	if (onUpdate) {
+		const updateResult = onUpdate(text, { nextUpdateInMilliseconds: timeout });
+		const shouldCancel = updateResult === false;
+		if (!shouldCancel && timeout > 0) {
+			setTimeout(() => {
+				formatRelative(formatFunction)(inputDate, {
+					absoluteFormat,
+					onUpdate,
+					rtf
+				});
+			}, timeout);
+		}
+	}
+
+	return text;
+};
+
+export const millisecondsPer = { second, minute, hour, day };
+export const formatRelativeDate = formatRelative(formatDate);
+export const formatRelativeDateTime = formatRelative(formatDateTime);

--- a/test/util/date-time.html
+++ b/test/util/date-time.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+<script src="/node_modules/chai/chai.js"></script>
+<script src="/node_modules/mocha/mocha.js"></script>
+<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+
+<script type="module">
+import {
+	formatRelativeDate,
+	formatRelativeDateTime,
+	millisecondsPer
+} from '../../src/util/date-time.js';
+
+const { second, minute, hour, day } = millisecondsPer;
+
+const noon = new Date(2000, 1, 1, 12, 0, 0, 0);
+const ninePM = new Date(2000, 1, 1, 21, 0, 0, 0);
+const threeAM = new Date(2000, 1, 1, 3, 0, 0, 0);
+const offset = (ms, origin = noon) => new Date(origin.getTime() + ms);
+const label = makeTime => `${makeTime}`.slice(6);
+
+const future = {
+	seconds: n => offset(n * second),
+	minutes: n => offset(n * minute),
+	hours: (n, origin = noon) => offset(n * hour, origin),
+	days: n => offset(n * day)
+};
+
+const past = {
+	seconds: (n, origin = noon) => offset(-n * second, origin),
+	minutes: (n, origin = noon) => offset(-n * minute, origin),
+	hours: (n, origin = noon) => offset(-n * hour, origin),
+	days: (n, origin = noon) => offset(-n * day, origin)
+};
+
+const shortDateRegex = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
+const shortDateTimeRegex = /^\d{1,2}\/\d{1,2}\/\d{4} \d{1,2}:\d{2} [AP]M$/;
+const fullDateRegex = /^\w+, \w+ \d{1,2}, \d{4}$/;
+const fullDateTimeRegex = /^\w+, \w+ \d{1,2}, \d{4} \d{1,2}:\d{2} [AP]M\s*$/;
+
+const enAlwaysShort = new Intl.RelativeTimeFormat('en', {
+	localeMatcher: 'best fit',
+	numeric: 'always',
+	style: 'short'
+});
+
+const frAutoLong = new Intl.RelativeTimeFormat('fr', {
+	localeMatcher: 'best fit',
+	numeric: 'auto',
+	style: 'long'
+});
+
+const relativeExamples = [
+	[() => past.seconds(1), '1 second ago', () => 29 * second],
+	[() => past.seconds(29), '29 seconds ago', () => Number(second)],
+	[() => future.seconds(1), 'in 1 second', () => 31 * second],
+	[() => future.seconds(28), 'in 28 seconds', () => 58 * second],
+	[() => past.seconds(30), 'this minute', () => Number(minute)],
+	[() => future.seconds(30), 'in 1 minute', () => Number(minute)],
+	[() => past.minutes(44), '44 minutes ago', () => Number(minute)],
+	[() => future.minutes(44), 'in 44 minutes', () => Number(minute)],
+	[() => past.minutes(45), '1 hour ago', () => 45 * minute],
+	[() => past.minutes(90.001), '2 hours ago', () => Number(hour)],
+	[() => past.minutes(100), '2 hours ago', () => 50 * minute],
+	[() => future.minutes(45), 'in 1 hour', () => 15 * minute],
+	[() => past.hours(5), '5 hours ago', () => 30 * minute],
+	[() => past.hours(5, threeAM), '5 hours ago', () => 30 * minute, { origin: threeAM }],
+	[() => future.hours(5), 'in 5 hours', () => 30 * minute],
+	[() => future.hours(5, ninePM), 'in 5 hours', () => 30 * minute, { origin: ninePM }],
+	[() => past.hours(6), '6 hours ago', () => 30 * minute],
+	[() => past.hours(6, threeAM), 'yesterday', () => 9 * hour, { origin: threeAM }],
+	[() => past.hours(27, threeAM), 'yesterday', () => 9 * hour, { origin: threeAM }],
+	[() => past.hours(27.001, threeAM), '2 days ago', () => 9 * hour, { origin: threeAM }],
+	[() => future.hours(6), 'in 6 hours', () => 30 * minute],
+	[() => future.hours(6, ninePM), 'tomorrow', () => 15 * hour, { origin: ninePM }],
+	[() => future.hours(26.999, ninePM), 'tomorrow', () => 15 * hour, { origin: ninePM }],
+	[() => future.hours(27, ninePM), 'in 2 days', () => 15 * hour, { origin: ninePM }],
+	[() => past.days(3.4999), '3 days ago', () => 24 * hour],
+	[() => future.days(3.4999), 'in 3 days', () => 24 * hour],
+	[() => past.days(1), 'yesterday', () => 24 * hour],
+	[() => past.days(1), '1 day ago', () => 24 * hour, { rtf: enAlwaysShort }],
+	[() => past.days(1), 'hier', () => 24 * hour, { rtf: frAutoLong }],
+	[() => past.minutes(23), '23 min. ago', () => Number(minute), { rtf: enAlwaysShort }]
+];
+
+describe('fuzzyDateTime', () => {
+	describe('formatRelativeDate', () => {
+		it('omits the time when formatting an absolute date', () => {
+			expect(formatRelativeDate(past.days(5), { origin: noon })).to.match(shortDateRegex);
+			expect(formatRelativeDate(future.days(5), { origin: noon })).to.match(shortDateRegex);
+		});
+
+		it('omits the time when formatting a long absolute date', () => {
+			expect(formatRelativeDate(past.days(5), { origin: noon, absoluteFormat: 'full' })).to.match(fullDateRegex);
+			expect(formatRelativeDate(future.days(5), { origin: noon, absoluteFormat: 'full' })).to.match(fullDateRegex);
+		});
+	});
+
+	describe('formatRelativeDateTime', () => {
+		it('includes the time when formatting an absolute date', () => {
+			expect(formatRelativeDateTime(past.days(5), { origin: noon })).to.match(shortDateTimeRegex);
+			expect(formatRelativeDateTime(future.days(5), { origin: noon })).to.match(shortDateTimeRegex);
+		});
+
+		it('includes the time when formatting a long absolute date', () => {
+			expect(formatRelativeDateTime(past.days(5), { origin: noon, absoluteFormat: 'full' })).to.match(fullDateTimeRegex);
+			expect(formatRelativeDateTime(future.days(5), { origin: noon, absoluteFormat: 'full' })).to.match(fullDateTimeRegex);
+		});
+	});
+
+	describe('formatRelative', () => {
+		describe('the readme examples', () => {
+			const origin = new Date(2015, 8, 23, 14, 5, 30);
+
+			const ruAlwaysShort = new Intl.RelativeTimeFormat('ru', {
+				localeMatcher: 'best fit',
+				numeric: 'always',
+				style: 'short'
+			});
+
+			it('example 1', () => {
+				expect(formatRelativeDateTime(
+					new Date(2015, 8, 23, 14, 5, 18),
+					{ origin }
+				)).to.equal('12 seconds ago');
+			});
+
+			it('example 2', () => {
+				expect(formatRelativeDateTime(
+					new Date(2015, 8, 24, 14, 5, 30),
+					{ origin, rtf: ruAlwaysShort }
+				)).to.equal('через 1 дн.');
+			});
+
+			it('example 3', async() => {
+				const invocations = [];
+				const actualDeltas = [];
+				const onUpdate = (text, opt) => {
+					invocations.push(text);
+					actualDeltas.push(opt.nextUpdateInMilliseconds);
+					return false;
+				};
+
+				const d = new Date(2015, 8, 23, 14, 5, 25);
+				const deltas = [
+					0,
+					25 * second,
+					Number(minute),
+					Number(minute)
+				];
+
+				let totalDelta = 0;
+				for (const delta of deltas) {
+					totalDelta += delta;
+					formatRelativeDate(d, {
+						origin: new Date(origin.getTime() + totalDelta),
+						onUpdate
+					});
+				}
+
+				formatRelativeDate(d, {
+					origin: new Date(origin.getTime() + (4 * day)),
+					onUpdate
+				});
+
+				deltas.push(Number(minute));
+				deltas.push(-1);
+				expect(actualDeltas).to.deep.equal(deltas.slice(1));
+				expect(invocations).to.deep.equal([
+					'5 seconds ago',
+					'this minute',
+					'1 minute ago',
+					'2 minutes ago',
+					'9/23/2015'
+				]);
+			});
+		});
+
+		it('uses absolute formatting for recent times when rtf is not available', () => {
+			expect(formatRelativeDate(past.seconds(5), { origin: noon })).to.not.match(shortDateRegex);
+			expect(formatRelativeDate(past.seconds(5), { origin: noon, rtf: false })).to.match(shortDateRegex);
+		});
+
+		relativeExamples.forEach(([makeTime, expected,, { rtf, origin = noon } = {}]) => {
+			it(`formats ${label(makeTime)} as ${expected}`, () => {
+				expect(formatRelativeDateTime(makeTime(), { origin, rtf })).to.equal(expected);
+			});
+		});
+
+		it('formats > 3 days as absolute', () => {
+			expect(formatRelativeDateTime(past.days(3.5))).to.match(shortDateTimeRegex);
+			expect(formatRelativeDateTime(future.days(3.5))).to.match(shortDateTimeRegex);
+		});
+
+		for (const [makeTime,, expected, { origin = noon } = {}] of relativeExamples) {
+			it(`updates ${label(makeTime)} in ${label(expected)}`, done => {
+				formatRelativeDateTime(makeTime(), {
+					origin,
+					onUpdate: (text, opt) => {
+						expect(opt.nextUpdateInMilliseconds)
+							.to.be.closeTo(expected(), 100);
+						done();
+						return false;
+					}
+				});
+			});
+		}
+	});
+});
+</script>


### PR DESCRIPTION
There is a [WIP PR to add this to BrightspaceUI/intl](https://github.com/BrightspaceUI/intl/pull/46). But a few questions about API design remain...

Adding `formatRelativeDate` to this project until it gets finalized in intl