### PR TITLE
Fix window.open for safari by moving it out of async context.

### DIFF
--- a/scripts/install-missing-bsi-dependencies.js
+++ b/scripts/install-missing-bsi-dependencies.js
@@ -2,7 +2,7 @@ const { exec } = require('child_process');
 const fs = require('fs');
 
 // Add your dependencies that have not been released yet and are not found in BSI
-const dependenciesToInstall = ['page'];
+const dependenciesToInstall = ['page', 'file-drop-element'];
 
 const args = process.argv.slice(2);
 const bsiPath = args && args[0];

--- a/src/components/two-column-layout.js
+++ b/src/components/two-column-layout.js
@@ -81,6 +81,11 @@ class TwoColumnLayout extends RtlMixin(LitElement) {
 		});
 	}
 
+	firstUpdated() {
+		super.firstUpdated();
+		this._resized();
+	}
+
 	render() {
 		return html`
 			<div id="container" class="container">


### PR DESCRIPTION
Disable actions if content list item is disabled (loading/ghost box).
Call resize for two column layout on firstUpdated.
Add file-drop-element to install-missing-bsi-dependencies.js script.