### PR TITLE
bypassing d2l-input-text validation

### DIFF
--- a/src/components/content-list/content-list-item.js
+++ b/src/components/content-list/content-list-item.js
@@ -115,6 +115,7 @@ class ContentListItem extends DependencyRequester(InternalLocalizeMixin(LitEleme
 				label-hidden
 				placeholder="${this.localize('titlePlaceholder')}"
 				value="${this.title}"
+				novalidate
 				@input="${this.titleInputChangedHandler}"
 				maxlength=100></d2l-input-text>
 			<d2l-button slot="footer" ?disabled=${this.confirmDisabled} id="rename-dialog-confirm" primary dialog-action="${dialogConfirmAction}">${this.localize('save')}</d2l-button>


### PR DESCRIPTION
Context: d2l-input-text is about to have validation enabled, which will suddenly start checking for min/max/required and a few other attributes. Since we're not sure how this will impact places that weren't expecting validation to suddenly start happening, we're disabling it.